### PR TITLE
Add OAuth method type for native apps to authenticate with

### DIFF
--- a/extensions/authentication.md
+++ b/extensions/authentication.md
@@ -11,7 +11,7 @@ Authentication options are given by Methods which are defined by the following t
 ```typescript
 {
 	"id": number | string;
-	"type": "OAUTH" | "FORM";
+	"type": "OAUTH" | "FORM" | "OAUTH_LOCAL";
 	"name": string;
 	"description"?: string;
 	"url": string;
@@ -22,6 +22,11 @@ Methods that use the "OAUTH" type of authentication provide a URL which will ini
 Client implementations have no control over this flow.
 Web clients served from the same origin as the server can simply redirect the page to the chosen flow and can expect to eventually be revisited at the completion of the flow with authentication in place.
 Other clients cannot expect this and should not use this type of method.
+
+Methods that use the "OAUTH_LOCAL" type function similar to "OAUTH" except that the client can guarantee that the final redirect URL will be `localhost:59415`.
+Thanks to this, a client set up a webserver on that address and listen for the response and forward it back to the server at `/auth/oauth/local`.
+The client can expect the server's response to contain the Set-Cookie header similarly to the "FORM" authentication method.
+Clients should send the indicated cookies back to the server for any future requests and should expect to be authenticated when they do so.
 
 Methods that use the "FORM" type of authentication provide a URL to which a client can POST a `username` and `password`.
 Responses from the provided URL should return a response with the Set-Cookie header when successful.


### PR DESCRIPTION
The port chosen here could reasonably have been anything in the dynamic/private range. The initial "5" puts the number into the range while "9415" is as close as I could get to spelling "pxls" with numbers.

There is still no way for third-party webapps to authenticate with OAuth since they cannot run webservers.