### PR TITLE
Rename socket endpoints and use more specific subscribe system

### DIFF
--- a/extensions/authentication.md
+++ b/extensions/authentication.md
@@ -41,12 +41,17 @@ Knowing this ID and secret implies a pre-existing relationship between the clien
 
 --------------------------------------------------------------------------------
 
-### /socket?extensions[]=authentication
+--------------------------------------------------------------------------------
+
+### /events?subscribe[]={events_list}&authenticate={"true" | "false"}
 *NOTE: The definitions here also apply to board sockets*
+
+If the query parameter `authenticate` is set to `true`, setting up a socket connection should be handled slightly differently — as detailed here.
 #### Client packets
-Unlike regular HTTP requests, websocket connections have a significant duration.
 Credentials are unlikely to expire over the course of a regular HTTP request.
 This allows regular requests to use headers for authentication.
+
+Unlike regular HTTP requests, websocket connections have a significant duration.
 Websocket connections are likely to last long enough that credentials will expire.
 This makes HTTP headers an inadequate method of authentication.
 
@@ -54,7 +59,7 @@ Clients wishing to authenticate a websocket connection are required to send auth
 Servers should not send any packets until the client's authentication is verified.
 Servers should keep connections open for at least 5 seconds to allow clients time to send an initial authenticate packet.
 ##### Authenticate
-Set authentication state.
+Sets the authentication state.
 ```typescript
 {
 	"type": "authenticate";

--- a/extensions/board_data_initial.md
+++ b/extensions/board_data_initial.md
@@ -45,10 +45,10 @@ Server implementations must support content-range headers which specify a range 
 
 --------------------------------------------------------------------------------
 
-### {board_uri}/socket?extensions[]=board_initial
+### {board_uri}/events?subscribe[]={events_list}
 #### Server packets
 ##### BoardUpdate
-The board has changed.
+Set `subscribe[]=data.initial` to add this field to the event.
 ```typescript
 {
 	"data"?: Partial<{
@@ -57,6 +57,6 @@ The board has changed.
 }
 ```
 #### Errors
-| Response Code | Cause                                       |
-|---------------|---------------------------------------------|
-| 403 Forbidden | Missing permission `socket.boards.initial`. |
+| Response Code | Cause                                            |
+|---------------|--------------------------------------------------|
+| 403 Forbidden | Missing permission `boards.events.data.initial`. |

--- a/extensions/board_data_mask.md
+++ b/extensions/board_data_mask.md
@@ -51,10 +51,10 @@ Server implementations must support content-range headers which specify a range 
 
 --------------------------------------------------------------------------------
 
-### {board_uri}/socket?extensions[]=board_mask
+### {board_uri}/events?subscribe[]={events_list}
 #### Server packets
 ##### BoardUpdate
-The board has changed.
+Set `subscribe[]=data.mask` to add this field to the event.
 ```typescript
 {
 	"data"?: Partial<{
@@ -63,6 +63,6 @@ The board has changed.
 }
 ```
 #### Errors
-| Response Code | Cause                                    |
-|---------------|------------------------------------------|
-| 403 Forbidden | Missing permission `socket.boards.mask`. |
+| Response Code | Cause                                         |
+|---------------|-----------------------------------------------|
+| 403 Forbidden | Missing permission `boards.events.data.mask`. |

--- a/extensions/board_data_timestamps.md
+++ b/extensions/board_data_timestamps.md
@@ -32,10 +32,10 @@ Timestamp is seconds since `created_at` as defined in `{board_uri}/info`.
 
 --------------------------------------------------------------------------------
 
-### {board_uri}/socket?extensions[]=board_timestamps
+### {board_uri}/events?subscribe[]={events_list}
 #### Server packets
 ##### BoardUpdate
-The board has changed.
+Set `subscribe[]=data.timestamps` to add this field to the event.
 ```typescript
 {
 	"data"?: Partial<{
@@ -44,6 +44,6 @@ The board has changed.
 }
 ```
 #### Errors
-| Response Code | Cause                                          |
-|---------------|------------------------------------------------|
-| 403 Forbidden | Missing permission `socket.boards.timestamps`. |
+| Response Code | Cause                                               |
+|---------------|-----------------------------------------------------|
+| 403 Forbidden | Missing permission `boards.events.data.timestamps`. |

--- a/extensions/board_lifecycle.md
+++ b/extensions/board_lifecycle.md
@@ -18,6 +18,33 @@ Implementing this extensions allows clients to update the board metadata.
 
 --------------------------------------------------------------------------------
 
+### /events?subscribe[]={events_list}
+#### Server packets
+##### BoardCreated
+Sent when a board is created.
+Set `subscribe[]=boards` to add this field to the event.
+```typescript
+{
+	"type": "board-created";
+	"board": Reference<Board>;
+}
+```
+##### BoardRemoved
+Sent when a board is deleted.
+Set `subscribe[]=boards` to add this field to the event.
+```typescript
+{
+	"type": "board-removed";
+	"board": Url;
+}
+```
+#### Errors
+| Response Code | Cause                               |
+|---------------|-------------------------------------|
+| 403 Forbidden | Missing permission `events.boards`. |
+
+--------------------------------------------------------------------------------
+
 ### {board_uri}
 #### POST
 Creates a new Board object.

--- a/extensions/board_lifecycle.md
+++ b/extensions/board_lifecycle.md
@@ -76,15 +76,15 @@ Deletes the Board object.
 
 --------------------------------------------------------------------------------
 
-### {board_uri}/socket?extensions[]=board_lifecycle
+### {board_uri}/events?subscribe[]={events_list}
 #### Server packets
 ##### BoardUpdate
-The board has changed.
+Set `subscribe[]=info` to add this field to the event.
 ```typescript
 {
 	"info"?: Partial<{
 		"name": string;
-		"shape": number[][]
+		"shape": number[][];
 		"palette": Map<number, {
 			"name": string;
 			"value": number;
@@ -93,6 +93,6 @@ The board has changed.
 }
 ```
 #### Errors
-| Response Code | Cause                                         |
-|---------------|-----------------------------------------------|
-| 403 Forbidden | Missing permission `socket.boards.lifecycle`. |
+| Response Code | Cause                                    |
+|---------------|------------------------------------------|
+| 403 Forbidden | Missing permission `boards.events.info`. |

--- a/extensions/board_lifecycle.md
+++ b/extensions/board_lifecycle.md
@@ -29,12 +29,12 @@ Set `subscribe[]=boards` to add this field to the event.
 	"board": Reference<Board>;
 }
 ```
-##### BoardRemoved
+##### BoardDeleted
 Sent when a board is deleted.
 Set `subscribe[]=boards` to add this field to the event.
 ```typescript
 {
-	"type": "board-removed";
+	"type": "board-deleted";
 	"board": Url;
 }
 ```

--- a/extensions/board_notices.md
+++ b/extensions/board_notices.md
@@ -36,10 +36,11 @@ If the [users extension](./users.md) is implemented, Notice objects gain an opti
 
 --------------------------------------------------------------------------------
 
-### {board_uri}/socket?extensions[]=board_notices
+### {board_uri}/events?subscribe[]={events_list}
 #### Server packets
 ##### BoardNoticeCreated
-There is a new board notice.
+Sent when a board notice is created.
+Set `subscribe[]=notices` to receive.
 ```typescript
 {
 	"type": "board-notice-created";
@@ -47,7 +48,8 @@ There is a new board notice.
 }
 ```
 ##### NoticeUpdated
-A board notice has been updated.
+Sent when a board notice is updated.
+Set `subscribe[]=notices` to receive.
 ```typescript
 {
 	"type": "board-notice-updated";
@@ -55,7 +57,8 @@ A board notice has been updated.
 }
 ```
 ##### NoticeRemoved
-A board notice has been removed.
+Sent whne a board notice is removed.
+Set `subscribe[]=notices` to receive.
 ```typescript
 {
 	"type": "board-notice-removed";
@@ -63,9 +66,9 @@ A board notice has been removed.
 }
 ```
 #### Errors
-| Response Code | Cause                                      |
-|---------------|--------------------------------------------|
-| 403 Forbidden | Missing permission `socket.board.notices`. |
+| Response Code | Cause                                       |
+|---------------|---------------------------------------------|
+| 403 Forbidden | Missing permission `boards.events.notices`. |
 
 --------------------------------------------------------------------------------
 
@@ -75,9 +78,9 @@ Lists all board notices.
 ##### Response
 A Paginated List of Notice References.
 ##### Errors
-| Response Code | Cause                                    |
-|---------------|------------------------------------------|
-| 403 Forbidden | Missing permission `board.notices.list`. |
+| Response Code | Cause                                     |
+|---------------|-------------------------------------------|
+| 403 Forbidden | Missing permission `boards.notices.list`. |
 
 #### POST
 Creates a board notice.
@@ -87,9 +90,9 @@ A Notice object.
 ##### Response
 The created Notice object.
 ##### Errors
-| Response Code | Cause                                    |
-|---------------|------------------------------------------|
-| 403 Forbidden | Missing permission `board.notices.post`. |
+| Response Code | Cause                                     |
+|---------------|-------------------------------------------|
+| 403 Forbidden | Missing permission `boards.notices.post`. |
 
 --------------------------------------------------------------------------------
 
@@ -99,9 +102,9 @@ Gets a board notice.
 ##### Response
 The Notice object.
 ##### Errors
-| Response Code | Cause                                   |
-|---------------|-----------------------------------------|
-| 403 Forbidden | Missing permission `board.notices.get`. |
+| Response Code | Cause                                    |
+|---------------|------------------------------------------|
+| 403 Forbidden | Missing permission `boards.notices.get`. |
 
 #### PATCH
 Updates a board notice.
@@ -111,13 +114,13 @@ A partial Notice object.
 ##### Response
 The updated Notice object.
 ##### Errors
-| Response Code | Cause                                     |
-|---------------|-------------------------------------------|
-| 403 Forbidden | Missing permission `board.notices.patch`. |
+| Response Code | Cause                                      |
+|---------------|--------------------------------------------|
+| 403 Forbidden | Missing permission `boards.notices.patch`. |
 
 #### DELETE
 Deletes the board notice.
 ##### Errors
-| Response Code | Cause                                      |
-|---------------|--------------------------------------------|
-| 403 Forbidden | Missing permission `board.notices.delete`. |
+| Response Code | Cause                                       |
+|---------------|---------------------------------------------|
+| 403 Forbidden | Missing permission `boards.notices.delete`. |

--- a/extensions/factions.md
+++ b/extensions/factions.md
@@ -51,6 +51,54 @@ If the [users extension](./users.md) is implemented, Member objects will also co
 
 --------------------------------------------------------------------------------
 
+### /events?subscribe[]={events_list}
+#### Server packets
+##### FactionCreated
+Sent when a faction is created.
+Set `subscribe[]=factions` to receive.
+```typescript
+{
+	"type": "faction-created";
+	"faction": Reference<Faction>;
+}
+```
+##### FactionUpdated
+Sent when a faction is updated.
+Set `subscribe[]=factions` to receive.
+```typescript
+{
+	"type": "faction-updated";
+	"faction": Reference<Faction>;
+}
+```
+##### FactionDeleted
+Sent when a faction is deleted.
+Set `subscribe[]=factions` to receive.
+```typescript
+{
+	"type": "faction-deleted";
+	"faction": Url;
+}
+```
+##### MemberChanged
+Sent when a faction member is updated.
+Set `subscribe[]=factions.members` to receive or `subscribe[]=factions.current.members` to receive for changes involving the user (those where they are the member, or they own an involved faction).
+```typescript
+{
+	"type": "faction-member-updated";
+	"faction": Reference<Faction>;
+	"member": Reference<Member>;
+}
+```
+#### Errors
+| Response Code | Cause                                                 |
+|---------------|-------------------------------------------------------|
+| 403 Forbidden | Missing permission `events.factions`.                 |
+| 403 Forbidden | Missing permission `events.factions.members`.         |
+| 403 Forbidden | Missing permission `events.factions.current.members`. |
+
+--------------------------------------------------------------------------------
+
 ### /factions
 #### GET
 Lists all factions.

--- a/extensions/placement_statistics.md
+++ b/extensions/placement_statistics.md
@@ -44,10 +44,11 @@ and a UserStatistics object as:
 
 --------------------------------------------------------------------------------
 
-### /socket?extensions[]=placement_statistics
+### /events?subscribe={events_list}
 #### Server packets
 ##### StatsUpdate
 The client user's total placement statistics have changed.
+Set `subscribe=stats` to receive this.
 ```typescript
 {
 	"type": "stats-updated";
@@ -57,14 +58,15 @@ The client user's total placement statistics have changed.
 #### Errors
 | Response Code | Cause                              |
 |---------------|------------------------------------|
-| 403 Forbidden | Missing permission `socket.stats`. |
+| 403 Forbidden | Missing permission `events.stats`. |
 
 --------------------------------------------------------------------------------
 
-### {board_uri}/socket?extensions[]=placement_statistics
+### {board_uri}/events?subscribe[]={events_list}
 #### Server packets
 ##### StatsUpdate
 The client user's placement statistics for this board have changed.
+Set `subscribe=stats` to receive this.
 ```typescript
 {
 	"type": "stats-updated";
@@ -72,9 +74,9 @@ The client user's placement statistics for this board have changed.
 }
 ```
 #### Errors
-| Response Code | Cause                              |
-|---------------|------------------------------------|
-| 403 Forbidden | Missing permission `socket.stats`. |
+| Response Code | Cause                                     |
+|---------------|-------------------------------------------|
+| 403 Forbidden | Missing permission `events.boards.stats`. |
 
 --------------------------------------------------------------------------------
 

--- a/extensions/reports.md
+++ b/extensions/reports.md
@@ -47,10 +47,11 @@ If the [users extension](./users.md) is implemented, Reports may additionally sp
 
 --------------------------------------------------------------------------------
 
-### /socket?extensions[]=reports
+### /events?subscribe[]={events_list}
 #### Server packets
 ##### ReportCreated
-There is a new report.
+Sent when a report is created.
+Set `subscribe[]=reports` to receive this event.
 ```typescript
 {
 	"type": "report-created";
@@ -58,7 +59,8 @@ There is a new report.
 }
 ```
 ##### ReportUpdated
-A report has been updated.
+Sent when a report is updated.
+Set `subscribe[]=reports` to receive this event.
 ```typescript
 {
 	"type": "report-updated";
@@ -66,17 +68,18 @@ A report has been updated.
 }
 ```
 ##### ReportRemoved
-A report has been removed.
+Sent when a report is removed.
+Set `subscribe[]=reports` to receive this event.
 ```typescript
 {
 	"type": "report-removed";
-	"report": Reference<Report>;
+	"report": Url;
 }
 ```
 #### Errors
 | Response Code | Cause                                |
 |---------------|--------------------------------------|
-| 403 Forbidden | Missing permission `socket.reports`. |
+| 403 Forbidden | Missing permission `events.reports`. |
 
 --------------------------------------------------------------------------------
 

--- a/extensions/roles.md
+++ b/extensions/roles.md
@@ -37,6 +37,53 @@ Role objects are defined by the following type:
 
 --------------------------------------------------------------------------------
 
+### /events?subscribe[]={events_list}
+#### Server packets
+##### RoleCreated
+Sent when a role is created.
+Set `subscribe[]=roles` to receive.
+```typescript
+{
+	"type": "role-created";
+	"role": Reference<Role>;
+}
+```
+##### RoleUpdated
+Sent when a role is updated.
+Set `subscribe[]=roles` to receive.
+```typescript
+{
+	"type": "role-updated";
+	"role": Reference<Role>;
+}
+```
+##### RoleDeleted
+Sent when a role is deleted.
+Set `subscribe[]=roles` to receive.
+```typescript
+{
+	"type": "role-deleted";
+	"role": Url;
+}
+```
+##### UserRolesUpdated
+Sent when the roles assigned to a user changes.
+Set `subscribe[]=users.roles` to receive, or `subscribe[]=users.current.roles` to receive for the current user.
+```typescript
+{
+	"type": "user-roles-updated";
+	"user": Url;
+}
+```
+#### Errors
+| Response Code | Cause                                            |
+|---------------|--------------------------------------------------|
+| 403 Forbidden | Missing permission `events.roles`.               |
+| 403 Forbidden | Missing permission `events.users.roles`.         |
+| 403 Forbidden | Missing permission `events.users.current.roles`. |
+
+--------------------------------------------------------------------------------
+
 ### {user_uri}/roles
 #### GET
 Lists all roles a user has.

--- a/extensions/roles.md
+++ b/extensions/roles.md
@@ -76,11 +76,12 @@ Set `subscribe[]=users.roles` to receive, or `subscribe[]=users.current.roles` t
 }
 ```
 #### Errors
-| Response Code | Cause                                            |
-|---------------|--------------------------------------------------|
-| 403 Forbidden | Missing permission `events.roles`.               |
-| 403 Forbidden | Missing permission `events.users.roles`.         |
-| 403 Forbidden | Missing permission `events.users.current.roles`. |
+| Response Code            | Cause                                            |
+|--------------------------|--------------------------------------------------|
+| 403 Forbidden            | Missing permission `events.roles`.               |
+| 403 Forbidden            | Missing permission `events.users.roles`.         |
+| 403 Forbidden            | Missing permission `events.users.current.roles`. |
+| 422 Unprocessable Entity | Current and non-current subscriptions overlap.   |
 
 --------------------------------------------------------------------------------
 

--- a/extensions/site_notices.md
+++ b/extensions/site_notices.md
@@ -37,10 +37,11 @@ If the [users extension](./users.md) is implemented, Notice objects gain an opti
 
 --------------------------------------------------------------------------------
 
-### /socket?extensions[]=site_notices
+### /events?subscribe[]={events_list}
 #### Server packets
 ##### SiteNoticeCreated
-There is a new site notice.
+Sent when a site notice is created.
+Set `subscribe[]=notices` to receive.
 ```typescript
 {
 	"type": "site-notice-created";
@@ -48,15 +49,17 @@ There is a new site notice.
 }
 ```
 ##### SiteNoticeUpdated
-A site notice has been updated.
+Sent when a site notice is updated.
+Set `subscribe[]=notices` to receive.
 ```typescript
 {
 	"type": "site-notice-updated";
 	"notice": Reference<Notice>;
 }
 ```
-##### SiteNoticeRemoved
-A site notice has been removed.
+##### SiteNoticetRemoved
+Sent when a site notice is removed.
+Set `subscribe[]=notices` to receive.
 ```typescript
 {
 	"type": "site-notice-removed";
@@ -66,7 +69,7 @@ A site notice has been removed.
 #### Errors
 | Response Code | Cause                                |
 |---------------|--------------------------------------|
-| 403 Forbidden | Missing permission `socket.notices`. |
+| 403 Forbidden | Missing permission `events.notices`. |
 
 --------------------------------------------------------------------------------
 

--- a/extensions/user_bans.md
+++ b/extensions/user_bans.md
@@ -28,6 +28,46 @@ This extension adds Ban objects which are described by following type:
 
 --------------------------------------------------------------------------------
 
+### /events?subscribe[]={events_list}
+#### Server packets
+##### BanCreated
+Sent when a ban is created.
+Set `subscribe[]=users.bans` to receive, or `subscribe[]=users.current.bans` to receive for the current user.
+```typescript
+{
+	"type": "ban-created";
+	"user": Reference<User>;
+	"ban": Reference<Ban>;
+}
+```
+##### BanUpdated
+Sent when a ban is updated
+Set `subscribe[]=bans` to receive, or `subscribe[]=users.current.bans` to receive for the current user.
+```typescript
+{
+	"type": "ban-updated";
+	"user": Reference<User>;
+	"ban": Reference<Ban>;
+}
+```
+##### BanDeleted
+Sent when a ban is deleted.
+Set `subscribe[]=bans` to receive, or `subscribe[]=users.current.bans` to receive for the current user.
+```typescript
+{
+	"type": "ban-deleted";
+	"user": Reference<User>;
+	"ban": Url;
+}
+```
+#### Errors
+| Response Code | Cause                                           |
+|---------------|-------------------------------------------------|
+| 403 Forbidden | Missing permission `events.users.bans`.         |
+| 403 Forbidden | Missing permission `events.users.current.bans`. |
+
+--------------------------------------------------------------------------------
+
 ### {board_uri}/pixels/{position}
 #### POST
 ##### Errors

--- a/extensions/users.md
+++ b/extensions/users.md
@@ -33,10 +33,12 @@ Placement objects gain an additional field due to this extension:
 
 --------------------------------------------------------------------------------
 
-### /socket?extensions[]=users
+### /events?subscribe[]={events_list}
 #### Server packets
 ##### UserUpdate
-The client user has changed.
+Sent when a user changes.
+Set `subscribe[]=users` to receive for all users.
+Set `subscribe[]=users.current` to receive for current user.
 ```typescript
 {
 	"type": "user-updated";
@@ -44,9 +46,10 @@ The client user has changed.
 }
 ```
 #### Errors
-| Response Code | Cause                              |
-|---------------|------------------------------------|
-| 403 Forbidden | Missing permission `socket.users`. |
+| Response Code | Cause                                     |
+|---------------|-------------------------------------------|
+| 403 Forbidden | Missing permission `events.user`.         |
+| 403 Forbidden | Missing permission `events.user.current`. |
 
 --------------------------------------------------------------------------------
 

--- a/extensions/users.md
+++ b/extensions/users.md
@@ -35,8 +35,8 @@ Placement objects gain an additional field due to this extension:
 
 ### /events?subscribe[]={events_list}
 #### Server packets
-##### UserUpdate
-Sent when a user changes.
+##### UserUpdated
+Sent when a user is updated.
 Set `subscribe[]=users` to receive for all users.
 Set `subscribe[]=users.current` to receive for current user.
 ```typescript
@@ -46,10 +46,11 @@ Set `subscribe[]=users.current` to receive for current user.
 }
 ```
 #### Errors
-| Response Code | Cause                                     |
-|---------------|-------------------------------------------|
-| 403 Forbidden | Missing permission `events.user`.         |
-| 403 Forbidden | Missing permission `events.user.current`. |
+| Response Code            | Cause                                          |
+|--------------------------|------------------------------------------------|
+| 403 Forbidden            | Missing permission `events.users`.             |
+| 403 Forbidden            | Missing permission `events.users.current`.     |
+| 422 Unprocessable Entity | Current and non-current subscriptions overlap. |
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This attempts to make WebSockets feel less like an implementation detail and more like a proper API feature, principally by renaming their endpoints to be "events" rather than simply "socket".

This also changes the previous extension-based event filtering system to a slightly finer-grained event subscription list with associated permissions for that. The query parameter used for this — "subscribe" — is currently subject to change while alternatives are considered. 